### PR TITLE
Replacing 'create' trigger for 'push'

### DIFF
--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -6,7 +6,7 @@ name: Step 0, Welcome
 # This will run every time we create push a commit to `main`.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
-  create:
+  push:
   workflow_dispatch:
 
 # Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication


### PR DESCRIPTION
The 'create' trigger does not get picked up once you create a repository from a template. Instead, the 'push' trigger should be used here for this purpose.